### PR TITLE
Add visualization module to distribution

### DIFF
--- a/distributions/Registration/build.gradle
+++ b/distributions/Registration/build.gradle
@@ -59,6 +59,7 @@ BuildUtils.addModuleDistributionDependencies(project, [
         ":server:modules:platform:filecontent",
         ":server:modules:platform:pipeline",
         ":server:modules:platform:query",
+        ":server:modules:platform:visualization",
         ":server:modules:platform:wiki",
         ":server:modules:UserReg-WS"
 ]


### PR DESCRIPTION
#### Rationale
The domain designer redesign accidentally introduced a dependency on the visualization module. Adding to distribution to prevent runtime errors when visiting domain designers.

#### Changes
* Add visualization module to 'Registration' distribution
