### PR TITLE
Make Registration distribution embedded

### DIFF
--- a/distributions/Registration/build.gradle
+++ b/distributions/Registration/build.gradle
@@ -39,5 +39,6 @@ project.task(
             dist.extraFileIdentifier='-Registration'
             dist.includeTarGZArchive=true
             dist.simpleDistribution=true
+            dist.embeddedArchiveType='tar.gz'
         }
 )

--- a/distributions/Registration/gradle.properties
+++ b/distributions/Registration/gradle.properties
@@ -1,1 +1,2 @@
 isOpenSource=true
+useEmbeddedTomcat

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Properties for standalone build
-gradlePluginsVersion=1.29.0_embeddedStandalone-SNAPSHOT
+gradlePluginsVersion=1.29.0
 artifactory_contextUrl=https://artifactory.labkey.com/artifactory
 
 apacheTomcatVersion=8.5.51

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Properties for standalone build
-gradlePluginsVersion=1.27.0
+gradlePluginsVersion=1.29.0_embeddedStandalone-SNAPSHOT
 artifactory_contextUrl=https://artifactory.labkey.com/artifactory
 
 apacheTomcatVersion=8.5.51


### PR DESCRIPTION
#### Rationale
Distributions that embed tomcat have fewer external dependencies to manage, simplifying manual and automated deployment process.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/128

#### Changes
* Update response distribution to contain embedded Tomcat