### PR TITLE
Parameter change from language to language code

### DIFF
--- a/src/com/hphc/mystudies/FdahpUserRegWSController.java
+++ b/src/com/hphc/mystudies/FdahpUserRegWSController.java
@@ -86,8 +86,8 @@ public class FdahpUserRegWSController extends SpringActionController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(FdahpUserRegWSController.class);
     public static final String NAME = "fdahpuserregws";
-    public static final String LANGUAGE_EN = "English";
-    public static final String LANGUAGE_SP = "Spanish";
+    public static final String LANGUAGE_EN = "en";
+    public static final String LANGUAGE_SP = "es";
     public static final String DEFAULT_LANGUAGE = LANGUAGE_EN;
     String language = DEFAULT_LANGUAGE;
 


### PR DESCRIPTION
Rationale

Language parameter updates

Related Pull Requests

N/A

Changes

In phase 1 we were supporting language name(English/Spanish) as one of the params in the request header, in phase 2 we have changed it to language code(en/es)