### PR TITLE
Issue 44015: Migrate remaining log4j 1.2 usages to 2.x

### DIFF
--- a/src/com/hphc/mystudies/FdahpUserRegWSController.java
+++ b/src/com/hphc/mystudies/FdahpUserRegWSController.java
@@ -33,7 +33,8 @@ import com.hphc.mystudies.model.UserAppDetails;
 import com.hphc.mystudies.model.UserDetails;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
@@ -96,7 +97,7 @@ public class FdahpUserRegWSController extends SpringActionController
         setActionResolver(_actionResolver);
     }
 
-    private static final Logger _log = Logger.getLogger(FdahpUserRegWSController.class);
+    private static final Logger _log = LogManager.getLogger(FdahpUserRegWSController.class);
 
     Properties configProp = FdahpUserRegUtil.getProperties();
 

--- a/src/com/hphc/mystudies/FdahpUserRegWSManager.java
+++ b/src/com/hphc/mystudies/FdahpUserRegWSManager.java
@@ -27,7 +27,8 @@ import com.hphc.mystudies.model.UserAppDetails;
 import com.hphc.mystudies.model.UserDetails;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.action.ApiSimpleResponse;
@@ -79,7 +80,7 @@ public class FdahpUserRegWSManager
         return _instance;
     }
 
-    private static final Logger _log = Logger.getLogger(FdahpUserRegWSManager.class);
+    private static final Logger _log = LogManager.getLogger(FdahpUserRegWSManager.class);
 
     public static void purgeContainer(Container c)
     {

--- a/src/com/hphc/mystudies/model/FdahpUserRegUtil.java
+++ b/src/com/hphc/mystudies/model/FdahpUserRegUtil.java
@@ -20,7 +20,8 @@ import com.hphc.mystudies.FdahpUserRegWSModule;
 import com.hphc.mystudies.bean.NotificationBean;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.files.FileContentService;
@@ -67,7 +68,7 @@ import static org.labkey.api.util.StringUtilsLabKey.DEFAULT_CHARSET;
  */
 public class FdahpUserRegUtil
 {
-    private static final Logger _log = Logger.getLogger(FdahpUserRegUtil.class);
+    private static final Logger _log = LogManager.getLogger(FdahpUserRegUtil.class);
     static String Email = "", password = "";
     static MailHelper.MultipartMessage msg;
 


### PR DESCRIPTION
#### Rationale
Recent events notwithstanding, we prefer log4j 2.x. Migrate 1.2 usages that were never converted or that snuck in after our big migration.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2899