### PR TITLE
Add test to verify 'labkeyVersion' for standalone build

### DIFF
--- a/init.gradle
+++ b/init.gradle
@@ -2,7 +2,7 @@ allprojects {
         // Properties for standalone build.
         // We define these here, instead of 'gradle.properties' to avoid overwriting properties in a standard build
     ext {
-        labkeyVersion = "22.1-SNAPSHOT"
+        labkeyVersion = "22.2-SNAPSHOT"
 
         buildFromSource = true
 

--- a/init.gradle
+++ b/init.gradle
@@ -2,7 +2,7 @@ allprojects {
         // Properties for standalone build.
         // We define these here, instead of 'gradle.properties' to avoid overwriting properties in a standard build
     ext {
-        labkeyVersion = "21.7-SNAPSHOT"
+        labkeyVersion = "22.1-SNAPSHOT"
 
         buildFromSource = true
 

--- a/test/src/org/labkey/test/tests/registration/RegistrationStandaloneVersionTest.java
+++ b/test/src/org/labkey/test/tests/registration/RegistrationStandaloneVersionTest.java
@@ -1,0 +1,35 @@
+package org.labkey.test.tests.registration;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.labkey.test.TestFileUtils;
+import org.labkey.test.io.Grep;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+public class RegistrationStandaloneVersionTest
+{
+
+    /**
+     * 'labkeyVersion' defined in 'init.gradle' for standalone build should match version from standard build
+     */
+    @Test
+    public void testVersionForStandaloneBuild() throws IOException
+    {
+        final File root = new File(TestFileUtils.getLabKeyRoot());
+        final File rootProperties = new File(root, "gradle.properties");
+        final File initGradle = new File(root, "server/modules/UserReg-WS/init.gradle");
+        final Pattern versionPattern = Pattern.compile("labkeyVersion ?=[^0-9]*([0-9]+\\.[0-9]+)");
+
+        final String rootVersion = Grep.findMatch(rootProperties, versionPattern);
+        Assert.assertNotNull("Unable to determine 'labkeyVersion' from " + rootProperties.getAbsolutePath(), rootVersion);
+
+        final String standaloneVersion = Grep.findMatch(initGradle, versionPattern);
+        Assert.assertNotNull("Unable to determine 'labkeyVersion' from " + initGradle.getAbsolutePath(), standaloneVersion);
+
+        Assert.assertEquals("Version for standalone build doesn't equal root LabKey version", rootVersion, standaloneVersion);
+    }
+
+}


### PR DESCRIPTION
#### Rationale
This will remind us to update the version with each release until we can automate the process.

#### Changes
* Add test to verify 'labkeyVersion' for standalone build
* Update 'labkeyVersion' for 22.2
