### PR TITLE
Update test API to match server-side changes

### DIFF
--- a/test/src/com/hphc/remoteapi/fdahpuserregws/AppPropertiesUpdateCommand.java
+++ b/test/src/com/hphc/remoteapi/fdahpuserregws/AppPropertiesUpdateCommand.java
@@ -2,18 +2,13 @@ package com.hphc.remoteapi.fdahpuserregws;
 
 import com.hphc.remoteapi.fdahpuserregws.params.AppPropertiesDetails;
 import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.PostCommand;
 
-public class AppPropertiesUpdateCommand extends BaseRegistrationCommand<CommandResponse>
+public class AppPropertiesUpdateCommand extends PostCommand<CommandResponse>
 {
     public AppPropertiesUpdateCommand(AppPropertiesDetails appProperties)
     {
-        super("appPropertiesUpdate", null, null);
+        super(BaseRegistrationCommand.CONTROLLER, "appPropertiesUpdate");
         setJsonObject(appProperties.toJSONObject());
-    }
-
-    @Override
-    protected String getRequestType()
-    {
-        return "POST";
     }
 }

--- a/test/src/com/hphc/remoteapi/fdahpuserregws/BaseRegistrationCommand.java
+++ b/test/src/com/hphc/remoteapi/fdahpuserregws/BaseRegistrationCommand.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 public class BaseRegistrationCommand<ResponseType extends CommandResponse> extends Command<ResponseType>
 {
-    private static final String CONTROLLER = "fdahpuserregws";
+    public static final String CONTROLLER = "fdahpuserregws";
 
     private final RegistrationSession _session;
 

--- a/test/src/org/labkey/test/tests/registration/MyStudiesRegistrationTest.java
+++ b/test/src/org/labkey/test/tests/registration/MyStudiesRegistrationTest.java
@@ -496,7 +496,7 @@ public class MyStudiesRegistrationTest extends BaseWebDriverTest
 
     private CommandResponse updateAppProperties(AppPropertiesDetails appProperties) throws IOException, CommandException
     {
-        return executeRegistrationCommand(new AppPropertiesUpdateCommand(appProperties));
+        return new AppPropertiesUpdateCommand(appProperties).execute(createDefaultConnection(), "/");
     }
 
     @LogMethod


### PR DESCRIPTION
#### Rationale
The endpoint for updating app properties was updated to be a more standard API. The test API wrapper needs to use the standard PostCommand to function.

#### Related Pull Requests
* https://github.com/FDA-MyStudies/UserReg-WS/pull/28

#### Changes
* Use standard `PostCommand` for `AppPropertiesUpdateCommand`
