### PR TITLE
Rename action branch to develop

### DIFF
--- a/.github/workflows/branch_release.yml
+++ b/.github/workflows/branch_release.yml
@@ -18,6 +18,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Create branches and PRs
-        uses: LabKey/gitHubActions/branch-release@master
+        uses: LabKey/gitHubActions/branch-release@develop
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge_release.yml
+++ b/.github/workflows/merge_release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Merge PR
-        uses: LabKey/gitHubActions/merge-release@master
+        uses: LabKey/gitHubActions/merge-release@develop
         with:
           target_branch: ${{ github.event.pull_request.base.ref }}
           merge_branch: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Validate PR Branches
-        uses: labkey-tchad/gitHubActions/validate-pr@master
+        uses: labkey-tchad/gitHubActions/validate-pr@develop
         with:
           pr_base: ${{ github.event.pull_request.base.ref }}
           pr_head: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
#### Rationale
Missed this repo when updating the default branch of `gitHubActions`.

#### Related Pull Requests
* https://github.com/FDA-MyStudies/Response/pull/11

#### Changes
* Rename action branch to develop
