### PR TITLE
Update 'labkeyVersion' for standalone build

### DIFF
--- a/init.gradle
+++ b/init.gradle
@@ -2,7 +2,7 @@ allprojects {
         // Properties for standalone build.
         // We define these here, instead of 'gradle.properties' to avoid overwriting properties in a standard build
     ext {
-        labkeyVersion = "22.2-SNAPSHOT"
+        labkeyVersion = "22.3-SNAPSHOT"
 
         buildFromSource = true
 


### PR DESCRIPTION
#### Rationale
We define 'labkeyVersion' in this module to allow it to build outside of a standard LabKey enlistment. It needs to be updated periodically.
