### PR TITLE
Update standalone build version to 22.5

### DIFF
--- a/init.gradle
+++ b/init.gradle
@@ -2,7 +2,7 @@ allprojects {
         // Properties for standalone build.
         // We define these here, instead of 'gradle.properties' to avoid overwriting properties in a standard build
     ext {
-        labkeyVersion = "22.4-SNAPSHOT"
+        labkeyVersion = "22.5-SNAPSHOT"
 
         buildFromSource = true
 


### PR DESCRIPTION
#### Rationale
`labkeyVersion` for standalone build should match server

#### Related Pull Requests
* https://github.com/LabKey/server/pull/231

#### Changes
* Update standalone build version to 22.5-SNAPSHOT
