### PR TITLE
Auto-generate jars.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 enlistment.properties
 .idea/
 dependencies.txt
+jars.txt

--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,23 @@
  *
  */
 
+import org.labkey.gradle.util.BuildUtils;
+import org.labkey.gradle.util.ExternalDependency
+
 plugins {
     id 'org.labkey.build.module'
     id 'org.labkey.build.standalone'
 }
 
-project.dependencies {
-    external 'com.eatthepath:pushy:0.14.1'
-    external group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
-}
+BuildUtils.addExternalDependency(
+    project,
+    new ExternalDependency(
+        "com.eatthepath:pushy:0.14.1",
+        "Pushy",
+        "Pushy",
+        "https://pushy-apns.org/",
+        ExternalDependency.MIT_LICENSE_NAME,
+        ExternalDependency.MIT_LICENSE_URL,
+        "Java Apple Push Notification Service Library"
+    )
+)

--- a/resources/credits/jars.txt
+++ b/resources/credits/jars.txt
@@ -1,5 +1,0 @@
-{table}
-Filename|Component|Version|Source|License|Purpose
-pushy-0.14.1.jar|pushy|0.14.1|{link:pushy|https://pushy-apns.org/}|{link:MIT|https://github.com/jchambers/pushy/blob/master/LICENSE.md}|Java Apple Push Notification Service Library
-slf4j-api-1.7.33.jar|SLF4J API|1.7.33|{link:SLF4J|http://www.slf4j.org/}|{link:MIT|http://www.slf4j.org/license.html}|Simple Logging Facade for Java
-{table}


### PR DESCRIPTION
#### Rationale
Our build can now auto-generate the `jars.txt` credits file, simplifying maintenance