### PR TITLE
Migrate test commands to Java remote API v3.0.0

### DIFF
--- a/test/src/com/hphc/remoteapi/fdahpuserregws/BaseRegistrationCommand.java
+++ b/test/src/com/hphc/remoteapi/fdahpuserregws/BaseRegistrationCommand.java
@@ -1,11 +1,11 @@
 package com.hphc.remoteapi.fdahpuserregws;
 
 import com.hphc.remoteapi.fdahpuserregws.params.RegistrationSession;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.json.simple.JSONObject;
 import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;

--- a/test/src/com/hphc/remoteapi/fdahpuserregws/NoCsrfConnection.java
+++ b/test/src/com/hphc/remoteapi/fdahpuserregws/NoCsrfConnection.java
@@ -1,6 +1,6 @@
 package com.hphc.remoteapi.fdahpuserregws;
 
-import org.apache.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequest;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.GuestCredentialsProvider;
 


### PR DESCRIPTION
#### Rationale
Update test commands for Java remote API v3.0.0 compatibility

#### Related Pull Requests
* https://github.com/LabKey/server/pull/320