### PR TITLE
Migrate labkey-client-api to use a modern JSON library: JSON-java

### DIFF
--- a/src/com/hphc/mystudies/CreateFolderCommand.java
+++ b/src/com/hphc/mystudies/CreateFolderCommand.java
@@ -1,6 +1,6 @@
 package com.hphc.mystudies;
 
-import org.json.simple.JSONObject;
+import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.PostCommand;
 

--- a/test/src/com/hphc/remoteapi/fdahpuserregws/BaseRegistrationCommand.java
+++ b/test/src/com/hphc/remoteapi/fdahpuserregws/BaseRegistrationCommand.java
@@ -37,12 +37,6 @@ public class BaseRegistrationCommand<ResponseType extends CommandResponse> exten
     }
 
     @Override
-    public BaseRegistrationCommand<ResponseType> copy()
-    {
-        return new BaseRegistrationCommand<>(getActionName(), _session);
-    }
-
-    @Override
     public ResponseType execute(Connection connection, String folderPath) throws IOException, CommandException
     {
         if (!(connection instanceof NoCsrfConnection))

--- a/test/src/com/hphc/remoteapi/fdahpuserregws/BaseRegistrationCommand.java
+++ b/test/src/com/hphc/remoteapi/fdahpuserregws/BaseRegistrationCommand.java
@@ -6,7 +6,7 @@ import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.json.simple.JSONObject;
+import org.json.JSONObject;
 import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
@@ -124,7 +124,7 @@ public class BaseRegistrationCommand<ResponseType extends CommandResponse> exten
             throw new IllegalArgumentException("JSON body will only be included in 'POST' requests");
         }
         _json.clear();
-        _json.putAll(json);
+        json.forEach(_json::put);
     }
 
     @Override

--- a/test/src/com/hphc/remoteapi/fdahpuserregws/LoginCommand.java
+++ b/test/src/com/hphc/remoteapi/fdahpuserregws/LoginCommand.java
@@ -1,6 +1,6 @@
 package com.hphc.remoteapi.fdahpuserregws;
 
-import org.json.simple.JSONObject;
+import org.json.JSONObject;
 
 import java.util.Map;
 

--- a/test/src/com/hphc/remoteapi/fdahpuserregws/LoginCommand.java
+++ b/test/src/com/hphc/remoteapi/fdahpuserregws/LoginCommand.java
@@ -15,7 +15,7 @@ public class LoginCommand extends BaseRegistrationCommand<LoginResponse>
     @Override
     protected LoginResponse createResponse(String text, int status, String contentType, JSONObject json)
     {
-        return new LoginResponse(text, status, contentType, json, this.copy());
+        return new LoginResponse(text, status, contentType, json, this);
     }
 
     @Override

--- a/test/src/com/hphc/remoteapi/fdahpuserregws/LoginResponse.java
+++ b/test/src/com/hphc/remoteapi/fdahpuserregws/LoginResponse.java
@@ -1,7 +1,7 @@
 package com.hphc.remoteapi.fdahpuserregws;
 
 import com.hphc.remoteapi.fdahpuserregws.params.RegistrationSession;
-import org.json.simple.JSONObject;
+import org.json.JSONObject;
 import org.labkey.remoteapi.CommandResponse;
 
 public class LoginResponse extends CommandResponse

--- a/test/src/com/hphc/remoteapi/fdahpuserregws/params/AppPropertiesDetails.java
+++ b/test/src/com/hphc/remoteapi/fdahpuserregws/params/AppPropertiesDetails.java
@@ -1,6 +1,6 @@
 package com.hphc.remoteapi.fdahpuserregws.params;
 
-import org.json.simple.JSONObject;
+import org.json.JSONObject;
 
 /**
  * Mirrors 'com.hphc.mystudies.bean.AppPropertiesDetailsBean'


### PR DESCRIPTION
#### Rationale
labkey-client-api was using an old, unsupported JSON library