### PR TITLE
Update LabKey dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ import org.labkey.gradle.util.BuildUtils;
 import org.labkey.gradle.util.ExternalDependency
 
 plugins {
-    id 'org.labkey.build.module'
     id 'org.labkey.build.standalone'
+    id 'org.labkey.build.module'
 }
 
 BuildUtils.addExternalDependency(

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ gradlePluginsVersion=1.36.0
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 apacheTomcatVersion=9.0.65
-labkeyClientApiVersion=3.0.0
+labkeyClientApiVersion=4.0.0-SNAPSHOT
 servletApiVersion=4.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ gradlePluginsVersion=1.36.0
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 apacheTomcatVersion=9.0.65
-labkeyClientApiVersion=4.0.0-SNAPSHOT
+labkeyClientApiVersion=4.0.0
 servletApiVersion=4.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Properties for standalone build
-gradlePluginsVersion=1.35.0
+gradlePluginsVersion=1.36.0
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 apacheTomcatVersion=9.0.65


### PR DESCRIPTION
#### Rationale
In the upcoming gradle plugin release, the `fileModule` plugin will depend on extensions defined by the `standalone` plugin. Just need to switch the order that they are applied.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/157

#### Changes
* Update order of applying plugins
