### PR TITLE
Upgrade to latest Java remote API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ gradlePluginsVersion=1.39.1
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 apacheTomcatVersion=9.0.70
-labkeyClientApiVersion=5.0.0
+labkeyClientApiVersion=5.0.1-fix_fixup-SNAPSHOT
 servletApiVersion=4.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ gradlePluginsVersion=1.39.1
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 apacheTomcatVersion=9.0.70
-labkeyClientApiVersion=5.0.1-fix_fixup-SNAPSHOT
+labkeyClientApiVersion=5.0.1
 servletApiVersion=4.0.1


### PR DESCRIPTION
#### Rationale
v5.0.1 includes a data fix-up fix

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/49