### PR TITLE
Avoid unnecessary Gradle task configuration

### DIFF
--- a/distributions/Registration/build.gradle
+++ b/distributions/Registration/build.gradle
@@ -7,10 +7,10 @@
  *
  */
 
+
 import org.labkey.gradle.task.ModuleDistribution
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
-import org.labkey.gradle.plugin.Distribution
 
 plugins {
     id 'org.labkey.build.distribution'
@@ -29,15 +29,12 @@ BuildUtils.addModuleDistributionDependencies(project, [BuildUtils.getApiProjectP
                                                        BuildUtils.getPlatformModuleProjectPath(project.gradle, "wiki"),
 ])
 
-project.task(
-        "distribution",
-        group: GroupNames.DISTRIBUTION,
-        type: ModuleDistribution,
+project.tasks.register("distribution", ModuleDistribution)
         {ModuleDistribution dist ->
+            group GroupNames.DISTRIBUTION
             dist.subDirName='Registration'
             dist.extraFileIdentifier='-Registration'
             dist.includeTarGZArchive=true
             dist.simpleDistribution=true
             dist.embeddedArchiveType='tar.gz'
         }
-)

--- a/distributions/Registration/build.gradle
+++ b/distributions/Registration/build.gradle
@@ -11,6 +11,7 @@
 import org.labkey.gradle.task.ModuleDistribution
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
+import org.labkey.gradle.plugin.Distribution
 
 plugins {
     id 'org.labkey.build.distribution'


### PR DESCRIPTION
#### Rationale
Using [task configuration avoidance APIs](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) can make builds more efficient.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/171

#### Changes
* Update gradle task references to avoid unnecessary configuration