### PR TITLE
Update to newest Netty release, 4.1.94

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ labkeyClientApiVersion=5.2.0
 servletApiVersion=4.0.1
 
 # Keep this in sync with the version pinned in the top-level LabKey build to ensure consistency with Docker module
-nettyVersion=4.1.91.Final
+nettyVersion=4.1.94.Final


### PR DESCRIPTION
#### Rationale
Make the dependency consistency check happy

#### Related Pull Requests
* https://github.com/LabKey/server/pull/508

#### Changes
* Update netty version to sync with other modules
