### PR TITLE
Add nonce

### DIFF
--- a/src/com/hphc/mystudies/appProperties.jsp
+++ b/src/com/hphc/mystudies/appProperties.jsp
@@ -5,7 +5,7 @@ To reset the Registration Server properties, enter JSON text in the box and clic
 <textarea id="json" rows="30" cols="80" style="width:100%"></textarea>
 <%= button("Done").href(urlProvider(AdminUrls.class).getAdminConsoleURL()) %>
 <%= button("Submit").onClick("submit();")%>
-<script>
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
     function submit() {
         LABKEY.Ajax.request({
             url: LABKEY.ActionURL.buildURL("fdahpuserregws", "appPropertiesUpdate.api"),


### PR DESCRIPTION
#### Rationale
Adding a nonce to all `<script>` blocks allows us to run with a stricter Content Security Policy, one that disallows all unsafe inline script.